### PR TITLE
docs: fix whitespace error in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# mode-grammar-builder
+# mode-grammar-builder
 
 > Build a jison grammar for a mode-grammar-builder mode
 


### PR DESCRIPTION
It looks like we accidentally added non-breaking space after the '#' in the
first line of the README. This corrects it to a regular space.